### PR TITLE
feat: Create and refine WeChat Mini-Game Expansion Pack

### DIFF
--- a/expansion-packs/bmad-wechat-mini-game-dev/README.md
+++ b/expansion-packs/bmad-wechat-mini-game-dev/README.md
@@ -1,33 +1,42 @@
 # BMad Expansion Pack: WeChat Mini-Game Development
 
-**Version:** 1.1.0
+**Version:** 1.0.0
+**Author:** Jules (AI Assistant)
 
 ## Overview
 
-This expansion pack provides specialized agents, templates, and tasks to accelerate the development of games for the WeChat Mini-Game platform using the BMad Method.
+This expansion pack provides a comprehensive, structured environment for developing WeChat Mini-Games using the BMad Method. It includes specialized agents, templates, and quality-control checklists that align with the best practices of other game development packs in the BMad ecosystem.
 
-It is designed to help you plan your game's structure, mechanics, and integration with WeChat's unique social and monetization features, as well as to speed up common development tasks.
+This pack is designed to help you plan your game's structure, mechanics, and integration with WeChat's unique features, while ensuring a high-quality, maintainable codebase.
 
 ---
 
 ## Components
 
+### Core Configuration
+
+*   **`config.yaml`**: Contains the metadata for this expansion pack.
+
 ### Specialist Agents
 
-*   **`@wechat-game-designer`**
-    *   An expert agent for planning and designing your WeChat mini-game. Its persona is optimized for the technical challenges of the Mini Game platform.
-*   **`@wechat-game-dev`**
-    *   A specialized developer agent fluent in the WeChat Mini Game framework, its APIs, and performance optimizations. This agent should be used for all implementation tasks.
+*   **`@wechat-game-designer`**: An expert agent for planning your game. It is aware of the technical standards in `development-guidelines.md`.
+*   **`@wechat-game-dev`**: A specialized developer agent for implementing game features, also aware of the development guidelines.
 
-### Document Template
+### Data & Guidelines
 
-*   **`gdd-wechat-template.yaml`**
-    *   A YAML-based template for a Game Design Document that includes special sections for WeChat-specific features like social login, sharing, and monetization.
+*   **`data/development-guidelines.md`**: The central source of truth for all technical preferences, coding standards, and anti-patterns for your project. Both agents use this file for context.
+
+### Templates
+
+*   **`templates/gdd-wechat-template.yaml`**: A YAML-based template for creating a comprehensive Game Design Document tailored for WeChat Mini-Games.
 
 ### Tasks
 
-*   **`scaffold-wechat-page`**
-    *   A task that can be used by the `@wechat-game-dev` agent to quickly create the four necessary files (`.js`, `.wxml`, `.wxss`, `.json`) for a new page in your mini-game.
+*   **`tasks/scaffold-wechat-page.md`**: A task for the `@wechat-game-dev` agent to quickly scaffold new pages.
+
+### Checklists
+
+*   **`checklists/game-story-dod-checklist.md`**: A "Definition of Done" checklist to ensure every story is completed to a consistent quality standard.
 
 ---
 
@@ -35,33 +44,26 @@ It is designed to help you plan your game's structure, mechanics, and integratio
 
 ### 1. Plan Phase
 
-1.  **Create the Game Design Document:** Use the specialized designer to plan your game (e.g., for a Tetris game).
+1.  **Create the Game Design Document:**
     ```bash
-    @wechat-game-designer *create-doc {template: 'gdd-wechat-template.yaml', game_name: 'Tetris'}
+    @wechat-game-designer *create-doc {template: 'gdd-wechat-template.yaml', game_name: 'YourGame'}
     ```
-2.  **Shard the GDD:** Use the Product Owner to break the design into actionable stories.
+2.  **Shard the GDD:**
     ```bash
     @po shard docs/gdd.md
     ```
 
 ### 2. Development Phase
 
-This phase is an iterative cycle for building each feature of your game.
-
-1.  **Initial Scaffolding (Optional):** If you need to create new pages, use the specialized dev agent.
+1.  **Draft a Story:**
     ```bash
-    @wechat-game-dev *scaffold-wechat-page
+    @sm *draft
     ```
-2.  **Development Cycle:** Repeat the following steps for each story.
-    *   **Draft Story:**
-        ```bash
-        @sm *draft
-        ```
-    *   **Implement Story:** Use the specialized developer agent.
-        ```bash
-        @wechat-game-dev *develop-story {path/to/story.md}
-        ```
-    *   **Review Story:** Get a quality review from the Test Architect.
-        ```bash
-        @qa *review {path/to/story.md}
-        ```
+2.  **Implement the Story:**
+    ```bash
+    @wechat-game-dev *develop-story {path/to/story.md}
+    ```
+3.  **Review and Verify:** Before marking as done, use the checklist and have the `@qa` agent review.
+    ```bash
+    @qa *review {path/to/story.md}
+    ```

--- a/expansion-packs/bmad-wechat-mini-game-dev/agents/wechat-game-designer.md
+++ b/expansion-packs/bmad-wechat-mini-game-dev/agents/wechat-game-designer.md
@@ -16,6 +16,8 @@ dependencies:
     - gdd-wechat-template.yaml
   tasks:
     - create-doc.md
+  data:
+    - ../data/development-guidelines.md
 ---
 
 ## Capabilities

--- a/expansion-packs/bmad-wechat-mini-game-dev/agents/wechat-game-dev.md
+++ b/expansion-packs/bmad-wechat-mini-game-dev/agents/wechat-game-dev.md
@@ -12,6 +12,8 @@ dependencies:
   tasks:
     - scaffold-wechat-page.md
     - execute-checklist.md # A core task for implementing stories
+  data:
+    - ../data/development-guidelines.md
 ---
 
 ## Capabilities

--- a/expansion-packs/bmad-wechat-mini-game-dev/checklists/game-story-dod-checklist.md
+++ b/expansion-packs/bmad-wechat-mini-game-dev/checklists/game-story-dod-checklist.md
@@ -1,0 +1,17 @@
+# Game Story - Definition of Done Checklist
+
+## Story: {{story_name}}
+
+---
+
+### Quality Assurance Checklist
+
+- [ ] **Code Complete:** All planned coding for the story is finished.
+- [ ] **Functionality Matches Acceptance Criteria:** The implementation meets all acceptance criteria defined in the story.
+- [ ] **Adheres to Development Guidelines:** The code follows all rules in `development-guidelines.md`.
+- [ ] **Unit Tests Written & Passing:** All new logic is covered by unit tests, and all tests are green.
+- [ ] **Integration Tests Written & Passing:** New features are covered by integration tests where applicable.
+- [ ] **No Linting Errors:** The code passes all linter checks without any errors or warnings.
+- [ ] **Code Peer Reviewed:** A team member has reviewed and approved the code changes.
+- [ ] **Documentation Updated:** Any relevant documentation (e.g., READMEs, API docs) has been updated.
+- [ ] **Feature Works on Target Device:** The feature has been tested and works correctly on a physical test device.

--- a/expansion-packs/bmad-wechat-mini-game-dev/config.yaml
+++ b/expansion-packs/bmad-wechat-mini-game-dev/config.yaml
@@ -1,0 +1,8 @@
+# <!-- Powered by BMAD™ Core -->
+name: bmad-wechat-mini-game-dev
+version: 1.0.0
+short-title: WeChat Mini Game Dev Pack
+description: >-
+  Game Development expansion pack for BMad Method - WeChat Mini Game focused
+author: Jules (AI Assistant)
+slashPrefix: bmadwmg

--- a/expansion-packs/bmad-wechat-mini-game-dev/data/development-guidelines.md
+++ b/expansion-packs/bmad-wechat-mini-game-dev/data/development-guidelines.md
@@ -1,0 +1,51 @@
+# WeChat Mini Game Development Guidelines
+
+This document provides the core technical preferences, coding standards, and anti-patterns for developing WeChat Mini Games with this expansion pack. Agents will reference this document to ensure consistency and quality.
+
+---
+
+## 1. Technical Preferences
+
+### Framework
+- **WeChat Mini Game Base Library:** v2.25.3 or higher
+- **State Management:** `mobx-miniprogram-bindings` is preferred for complex state.
+- **UI Component Library:** `WeUI` is approved for use.
+
+### API Conventions
+- All backend requests must use the `wx.request` API wrapper provided in `utils/request.js`.
+- **Authentication:** Tokens must be passed in the header as 'X-Auth-Token'.
+- **Base API URL:** `https://api.yourgame.com/v1`
+
+---
+
+## 2. Coding Standards
+
+### File and Directory Structure
+- All pages must be located in the `/pages` directory.
+- All reusable components must be located in the `/components` directory.
+- Utility functions should be placed in `/utils`.
+- Each page or component must consist of four files: `.js`, `.wxml`, `.wxss`, and `.json`.
+
+### JavaScript (`.js`)
+- Always use strict mode (`'use strict';`).
+- Use `const` for variables that are not reassigned, and `let` for variables that are. Avoid `var`.
+- All asynchronous operations must return a Promise. Use `async/await` for cleaner code.
+- Keep business logic out of the Page/Component lifecycle methods. Create separate helper methods.
+- Use `this.setData()` for all UI updates. Avoid direct manipulation of `this.data`.
+
+### WXML (`.wxml`)
+- Use `wx:if` and `wx:else` for conditional rendering. Use the `hidden` attribute for simple show/hide toggles.
+- Use `wx:for` for list rendering. Always specify a `wx:key` for performance.
+- Bind events using `bind:tap` or `catch:tap`. Use `catch` to prevent event bubbling when necessary.
+
+### WXSS (`.wxss`)
+- Use `rpx` (responsive pixels) for sizing and positioning to ensure adaptability across different screen sizes.
+- Define common styles in a global stylesheet (`/app.wxss`) and import them into component styles where needed.
+- Keep styles scoped to their component to avoid conflicts.
+
+---
+
+## 3. Anti-Patterns to Avoid
+- Do not use `wx.getStorageSync()` for large or frequently changing data. Use it only for static configuration or user preferences.
+- Avoid using `setTimeout` for UI updates; use `this.setData()` callbacks or `wx.nextTick`.
+- Do not place business logic inside `.wxml` files using `wxs`. Keep logic in the `.js` file.


### PR DESCRIPTION
This commit introduces a new expansion pack for WeChat Mini-Game development and includes significant refinements based on user feedback to ensure correctness and consistency with the project's architecture.

The new `bmad-wechat-mini-game-dev` expansion pack includes:
- A `config.yaml` for pack metadata.
- Specialized agents: `@wechat-game-designer` and `@wechat-game-dev`.
- A central `data/development-guidelines.md` for standards.
- A `checklists/game-story-dod-checklist.md` for quality control.
- A YAML-based GDD template and a page scaffolding task.
- A comprehensive `README.md`.

This work also includes the reversion of a previous, incorrect commit that modified `bmad-core` files. Those changes have been reverted, and the expansion pack is now correctly implemented to be fully self-contained.